### PR TITLE
Add withoutswap mode

### DIFF
--- a/test_check_memfreetotal.py
+++ b/test_check_memfreetotal.py
@@ -143,7 +143,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setCritical( "10%" )
         mem_free.setWarning( "60%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_OK )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
 
     #-----------------------------------------------
 
@@ -154,7 +154,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setCritical( "10%" )
         mem_free.setWarning( "94%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_OK )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
 
     #-----------------------------------------------
 
@@ -165,7 +165,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setCritical( "10%" )
         mem_free.setWarning( "80%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_OK )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
 
     #-----------------------------------------------
 
@@ -176,7 +176,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setCritical( "1024" )
         mem_free.setWarning( "2405972" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_OK )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
 
     #-----------------------------------------------
 
@@ -187,7 +187,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setCritical( "1024" )
         mem_free.setWarning( "6298216" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_OK )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
 
     #-----------------------------------------------
 
@@ -198,7 +198,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setCritical( "1024" )
         mem_free.setWarning( "1542928" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_OK )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
 
     #-----------------------------------------------
 
@@ -209,7 +209,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setCritical( "60%" )
         mem_free.setWarning( "61%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -220,7 +220,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setCritical( "90%" )
         mem_free.setWarning( "95%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -231,7 +231,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setCritical( "80%" )
         mem_free.setWarning( "81%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -242,7 +242,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setCritical( "1000000" )
         mem_free.setWarning( "2405973" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -253,7 +253,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setCritical( "5000000" )
         mem_free.setWarning( "6298217" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -264,7 +264,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setCritical( "500000" )
         mem_free.setWarning( "1542929" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -275,7 +275,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setCritical( "61%" )
         mem_free.setWarning( "62%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -286,7 +286,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setCritical( "95%" )
         mem_free.setWarning( "96%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -297,7 +297,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setCritical( "81%" )
         mem_free.setWarning( "82%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -308,7 +308,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setCritical( "2405973" )
         mem_free.setWarning( "2405974" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -319,7 +319,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setCritical( "6298217" )
         mem_free.setWarning( "6298218" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -330,7 +330,7 @@ SwapFree:              0 kB"""
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setCritical( "1542929" )
         mem_free.setWarning( "1542930" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -340,7 +340,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setWarning( "61%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -350,7 +350,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setWarning( "95%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -360,7 +360,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setWarning( "81%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -370,7 +370,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setWarning( "2405973" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -380,7 +380,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setWarning( "6298217" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -390,7 +390,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setWarning( "1542929" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_WARNING )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_WARNING )
 
     #-----------------------------------------------
 
@@ -400,7 +400,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setCritical( "61%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -410,7 +410,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setCritical( "95%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -420,7 +420,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setCritical( "81%" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -430,7 +430,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapUsed )
         mem_free.setCritical( "2405973" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -440,7 +440,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapFree )
         mem_free.setCritical( "6298217" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
 
     #-----------------------------------------------
 
@@ -450,7 +450,7 @@ SwapFree:              0 kB"""
         """
         mem_free = _MemFree( self.dataSwapNone )
         mem_free.setCritical( "1542929" )
-        self.assertEqual( mem_free.checkMemFree(), _MemFree.STATE_CRITICAL )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_CRITICAL )
         
     #-----------------------------------------------
 

--- a/test_check_memfreetotal.py
+++ b/test_check_memfreetotal.py
@@ -36,6 +36,21 @@ Buffers:          230164 kB
 Cached:          1228664 kB
 SwapTotal:             0 kB
 SwapFree:              0 kB"""
+        self.dataRHEL6 = """MemTotal:        3774832 kB
+MemFree:         1676628 kB
+Buffers:              84 kB
+Cached:           856536 kB
+Active(file):     225336 kB
+Inactive(file):   444076 kB
+SwapTotal:       4063228 kB
+SwapFree:        3611828 kB"""
+        self.dataRHEL7 = """MemTotal:        3774832 kB
+MemFree:         1690284 kB
+MemAvailable:    2228584 kB
+Buffers:              84 kB
+Cached:           853608 kB
+SwapTotal:       4063228 kB
+SwapFree:        3611828 kB"""
         pass
 
     #-----------------------------------------------
@@ -199,6 +214,50 @@ SwapFree:              0 kB"""
         mem_free.setCritical( "1024" )
         mem_free.setWarning( "1542928" )
         self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
+
+    #-----------------------------------------------
+
+    def test_validCheck_OK_7( self ):
+        """
+        バリデーション 正常チェック % スワップあり (RHEL 6)
+        """
+        mem_free = _MemFree( self.dataRHEL6 )
+        mem_free.setCritical( "10%" )
+        mem_free.setWarning( "60%" )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
+
+    #-----------------------------------------------
+
+    def test_validCheck_OK_8( self ):
+        """
+        バリデーション 正常チェック % スワップ未考慮 (RHEL 6)
+        """
+        mem_free = _MemFree( self.dataRHEL6 )
+        mem_free.setCritical( "10%" )
+        mem_free.setWarning( "60%" )
+        self.assertEqual( mem_free.checkMemFree( True ), _MemFree.STATE_OK )
+
+    #-----------------------------------------------
+
+    def test_validCheck_OK_9( self ):
+        """
+        バリデーション 正常チェック % スワップあり (RHEL 7)
+        """
+        mem_free = _MemFree( self.dataRHEL7 )
+        mem_free.setCritical( "10%" )
+        mem_free.setWarning( "60%" )
+        self.assertEqual( mem_free.checkMemFree( False ), _MemFree.STATE_OK )
+
+    #-----------------------------------------------
+
+    def test_validCheck_OK_10( self ):
+        """
+        バリデーション 正常チェック % スワップ未考慮 (RHEL 7)
+        """
+        mem_free = _MemFree( self.dataRHEL7 )
+        mem_free.setCritical( "10%" )
+        mem_free.setWarning( "50%" )
+        self.assertEqual( mem_free.checkMemFree( True ), _MemFree.STATE_OK )
 
     #-----------------------------------------------
 


### PR DESCRIPTION
## PR概要
1. `-s | --without_swap`オプションを付けることで、スワップ領域を加味しないチェックになるようにしました
    - webサーバ等ではレスポンスを重視する必要があり、スワップを使用する余裕が無いこともあるため
    - `-s`を付けても、他の引数に影響は与えません
1. ~RHEL5, RHEL6, RHEL7毎に空きメモリの算出方法が変わるので、それぞれ適応しました
    - 参考：http://nopipi.hatenablog.com/entry/2015/09/13/181026
1. テストスクリプトは、今回追加したメモリ算出方法を全て通過するように変更しました
    - 正常系のみ

## 動作確認環境
1. Ubuntu 16.04.6 TLS (RHEL6として動作しました)
1. CentOS 7.6.1810 (RHEL7として動作しました)